### PR TITLE
Replace `pipenv_install_opts` with special handling of the standard `install_command`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,9 +10,6 @@
   * Enable strict-pinning workflow with multiple python versions
   * New tox CLI option: `--pipenv-update` to explicitly (re)lock dependencies for multiple environments
 * testenv ini-setting, `skip_pipenv`: opt-out of all `pipenv` operations for the environment
-* Customize `pipenv` `install_deps` command:
-  * testenv ini-setting `pipenv_install_opts` / `TOX_PIPENV_INSTALL_OPTS`
-  * Environment variables take precedence over testenv ini-setting
 * Code restructuring for better modularity and readability
 * 100% unit and integration test coverage
 

--- a/README.md
+++ b/README.md
@@ -71,25 +71,6 @@ _bool_. Specified per `[testenv]` section.
 
 If true, this plugin will not take any action in the environment.
 
-## `pipenv_install_opts`
-
-_string_. Specified per `[testenv]` section.
-
-Override the args passed to `pipenv` during the `install_deps` stage.
-
-By default, the plugin will use `install --ignore-pipfile` if a `Pipfile_{envname}.lock`
-file is present and `install` when only a `Pipfile` is available.
-
-If this option is specified, the plugin will not modify or augment the argument list,
-however if `--pipenv-update` is specified and `update` is not present in the opts, an
-exception is raised.
-
-### `TOX_PIPENV_INSTALL_OPTS`
-
-_string_. Environment Variable.
-
-Global override for `pipenv_install_opts` will apply to all environments.
-
 # Virtual Environments
 
 This plugin will use whatever virtualenv tox creates for the test environment,

--- a/test/integration/data.py
+++ b/test/integration/data.py
@@ -12,6 +12,18 @@ TOX_INI_PIPFILE_SIMPLE = dedent(
 )
 
 
+TOX_INI_PIPFILE_INSTALL_COMMAND = dedent(
+    """
+    [tox]
+    skipsdist = True
+    envlist = py
+
+    [testenv]
+    install_command = {install_command}
+    commands = pip freeze""",
+)
+
+
 TOX_INI_DEPS_SIMPLE = dedent(
     """
     [tox]

--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -17,7 +17,7 @@ pytest_plugins = ["pytester"]
 
 def _expect_tox_to_fail(
     pass_pipenv_update,
-    pipenv_install_opts,
+    install_command,
     use_pipfile,
     use_pipfile_lock_env,
 ):
@@ -31,45 +31,29 @@ def _expect_tox_to_fail(
     want_update_but_will_raise = (
         pass_pipenv_update and not use_pipfile and not use_pipfile_lock_env
     )
-    # will hit this in plugin._install_args if _should_skip lets us through
-    custom_update_but_no_pipfile = (
-        pipenv_install_opts
-        and "update" in pipenv_install_opts
-        and not use_pipfile
-        and use_pipfile_lock_env
-    )
     # condition raised in plugin._install_args
     want_update_but_no_pipfile = pass_pipenv_update and not use_pipfile
-    # condition raised at the bottom of plugin._install_args
-    non_update_custom_mixed_with_update_arg = (
-        pass_pipenv_update
-        and pipenv_install_opts
-        and "update" not in pipenv_install_opts
+    default_install_command = install_command is None
+    want_update_but_no_pipenv_in_command = install_command and (
+        pass_pipenv_update and "pipenv" not in install_command
     )
     return (
-        want_update_but_will_raise
-        or custom_update_but_no_pipfile
-        or want_update_but_no_pipfile
-        or non_update_custom_mixed_with_update_arg
+        default_install_command
+        and (want_update_but_will_raise or want_update_but_no_pipfile)
+        or want_update_but_no_pipenv_in_command
     )
 
 
-@pytest.mark.parametrize(
-    "pip_pre", [True, False], ids=["pip_pre=True", "pip_pre=False"]
-)
 def test_end_to_end(
     pytester,
+    tox_ini,
     use_pipfile,
     use_pipfile_lock_env,
     pass_pipenv_update,
-    pipenv_install_opts,
+    install_command,
     pip_pre,
 ):
     """Call tox and validate the `pip freeze` output."""
-    tox_ini_content = TOX_INI_PIPFILE_SIMPLE
-    if pip_pre:
-        tox_ini_content += "\npip_pre = true"
-    pytester.makefile(".ini", tox=tox_ini_content)
     command = [sys.executable, "-m", "tox"]
     if not use_pipfile_lock_env:
         assert not (pytester.path / "Pipfile_py.lock").exists()
@@ -79,7 +63,7 @@ def test_end_to_end(
 
     if _expect_tox_to_fail(
         pass_pipenv_update=pass_pipenv_update,
-        pipenv_install_opts=pipenv_install_opts,
+        install_command=install_command,
         use_pipfile=use_pipfile,
         use_pipfile_lock_env=use_pipfile_lock_env,
     ):
@@ -92,22 +76,25 @@ def test_end_to_end(
             "py run-test: commands[0] | pip freeze",
         ]
     )
-    if pipenv_install_opts:
-        exp_install_cmd = list(shlex.split(pipenv_install_opts))
+    if install_command:
+        if "pipenv" not in install_command:
+            result.stdout.fnmatch_lines(["py pipenv: <disabled *"])
+            return
+        exp_install_cmd = list(
+            shlex.split(install_command.format(opts="", packages=""))
+        )
     elif pass_pipenv_update:
-        exp_install_cmd = ["update"]
+        exp_install_cmd = [sys.executable, "-m", "pipenv", "update"]
     else:
-        exp_install_cmd = ["install"]
-    if use_pipfile_lock_env and not pass_pipenv_update and not pipenv_install_opts:
+        exp_install_cmd = [sys.executable, "-m", "pipenv", "install"]
+    if use_pipfile_lock_env and not pass_pipenv_update and not install_command:
         exp_install_cmd.append("--ignore-pipfile")
-    if pip_pre and not pipenv_install_opts:
-        exp_install_cmd.append("--pre")
+    if pip_pre:
+        if install_command is None or "{opts}" in (install_command or ""):
+            exp_install_cmd.append("--pre")
     exp_path = pytester.path / ".tox" / "py" / "Pipfile"
     if "--ignore-pipfile" in exp_install_cmd:
         exp_path = str(exp_path) + ".lock"
-    if pipenv_install_opts and not use_pipfile:
-        # overriding the install command allows use w/o Pipfile
-        exp_path = None
     if pass_pipenv_update or use_pipfile or use_pipfile_lock_env:
         result.stdout.fnmatch_lines(
             [
@@ -120,7 +107,7 @@ def test_end_to_end(
             result.stdout.fnmatch_lines(["iterlist==0.4"])
     else:
         result.stdout.no_fnmatch_line("iterlist==*")
-    if pass_pipenv_update and not use_pipfile_lock_env:
+    if pass_pipenv_update and not use_pipfile_lock_env and not install_command:
         new_lock_file = pytester.path / "Pipfile_py.lock"
         assert new_lock_file.exists()
         new_lock_file_contents = new_lock_file.read_text()
@@ -153,9 +140,13 @@ def test_end_to_end_deps(pytester, use_pipfile, pass_pipenv_update, tox_ini):
         result.stdout.fnmatch_lines(["py installdeps: iterlist == 0.4"])
     result.stdout.fnmatch_lines(
         [
+            "py pipenv: <disabled *",
             "py run-test: commands[0] | pip freeze",
             "iterlist==0.4",
         ]
+    )
+    result.stdout.no_fnmatch_line(
+        "WARNING: test command found but not installed in testenv"
     )
 
 
@@ -169,7 +160,9 @@ def test_alt_pipfile(pytester, monkeypatch):
     exp_path = pytester.path / ".tox" / "py" / "Poopfile"
     result.stdout.fnmatch_lines(
         [
-            "py pipenv: <['install'] {}>".format(exp_path),
+            "py pipenv: <{} {}>".format(
+                [sys.executable, "-m", "pipenv", "install"], exp_path
+            ),
             "py run-test: commands[0] | pip freeze",
             "iterlist==0.4",
         ],
@@ -181,5 +174,5 @@ def test_no_deps_or_pipfile(pytester):
     command = [sys.executable, "-m", "tox"]
     result = pytester.run(*command)
     assert result.ret == 0
+    result.stdout.fnmatch_lines(["py pipenv: <disabled *"])
     result.stdout.no_fnmatch_line("iterlist==*")
-    result.stdout.no_fnmatch_line("py pipenv:*")

--- a/test/unit/test_addoption.py
+++ b/test/unit/test_addoption.py
@@ -6,4 +6,3 @@ def test_tox_addoption_smoke(mocker):
     tox_pipenv.plugin.tox_addoption(parser)
     assert parser.add_argument.call_args[0] == ("--pipenv-update",)
     assert parser.add_testenv_attribute.call_args_list[0][0] == ("skip_pipenv",)
-    assert parser.add_testenv_attribute.call_args_list[1][0] == ("pipenv_install_opts",)

--- a/test/unit/test_runenvreport.py
+++ b/test/unit/test_runenvreport.py
@@ -11,6 +11,7 @@ from tox_pipenv.plugin import (
 )
 
 
+@pytest.mark.usefixtures("default_install_command")
 @pytest.mark.parametrize(
     "do_clone_pipfile",
     [True, False],


### PR DESCRIPTION
In the spirit of avoiding custom behavior, remove the custom option `pipenv_install_opts`.

The loss of functionality is **not having the global override as an environment variable**. The slightly rough edge is **tox enforcing the specification of `{packages}` in the `install_command`.**

The improvements in functionality are:
  * the ability to opt-out of `tox-pipenv` via the use of a non-`pipenv` `install_command`
  * initialize/overwrite an environment-specific `Pipfile` via `install_command = pipenv install` while `deps` specified (v1 behavior)
  * no restriction on the use of `--pipenv-update` with a custom `install_command` (if a lockfile exists in `.tox/{envname}/Pipfile.lock`, it will be copied to `Pipfile_{envname}.lock`, but if not, then no problem)

Improved maintainability from reduced code and respecting envs using `install_command` for other purposes.