### PR TITLE
bring back `tox_testenv_create`

### DIFF
--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -49,9 +49,7 @@ def tox_ini(pytester):
 @pytest.fixture(
     params=[
         "pipenv install --dev {opts} {packages}",
-        "pipenv update --pre {packages}",
-        # XXX: can't use this because `python` is the venv python, not the tox python
-        # "python -m pipenv update --pre {packages}",
+        "python -m pipenv update --pre {packages}",
         "echo {opts} {packages}",
         None,
     ],

--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -1,3 +1,4 @@
+import glob
 import sys
 import shlex
 
@@ -100,7 +101,7 @@ def test_end_to_end(
     if pass_pipenv_update or use_pipfile or use_pipfile_lock_env:
         result.stdout.fnmatch_lines(
             [
-                "py pipenv: <{} {}>".format(exp_install_cmd, exp_path),
+                glob.escape(r"py pipenv: <{} {}>".format(exp_install_cmd, exp_path)),
             ]
         )
         if (use_pipfile and exp_install_cmd[0] in ("install", "update")) or (
@@ -162,8 +163,10 @@ def test_alt_pipfile(pytester, monkeypatch):
     exp_path = pytester.path / ".tox" / "py" / "Poopfile"
     result.stdout.fnmatch_lines(
         [
-            "py pipenv: <{} {}>".format(
-                [sys.executable, "-m", "pipenv", "install"], exp_path
+            glob.escape(
+                "py pipenv: <{} {}>".format(
+                    [sys.executable, "-m", "pipenv", "install"], exp_path
+                )
             ),
             "py run-test: commands[0] | pip freeze",
             "iterlist==0.4",

--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -80,6 +80,8 @@ def test_end_to_end(
         if "pipenv" not in install_command:
             result.stdout.fnmatch_lines(["py pipenv: <disabled *"])
             return
+        if install_command.startswith("python"):
+            install_command = install_command.replace("python", sys.executable)
         exp_install_cmd = list(
             shlex.split(install_command.format(opts="", packages=""))
         )

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -34,6 +34,7 @@ class MockEnvironmentConfig(object):
     sitepackages = attr.ib(default=False)
     pip_pre = attr.ib(default=False)
     skip_pipenv = attr.ib(default=False)
+    pipenv_venv = attr.ib(default=True)
     install_command = attr.ib(factory=list)
     allowlist_externals = attr.ib(factory=list)
 
@@ -82,7 +83,7 @@ class MockVenv(object):
     def getsupportedinterpreter(self):
         return "test-python"
 
-    def _pcall(self, *args, **kwargs):
+    def _pcall(self, *args, venv=True, **kwargs):
         return subprocess.Popen(*args, **kwargs)
 
     def _getresolvedeps(self):
@@ -178,3 +179,15 @@ def mock_for_Popen(mocker):
 @pytest.fixture
 def default_install_command(mocker):
     mocker.patch("tox_pipenv.plugin._has_default_install_command", return_value=True)
+
+
+@pytest.fixture(params=[True, False], ids=["pipenv_venv=True", "pipenv_venv=False"])
+def pipenv_venv(request, venv):
+    venv.envconfig.pipenv_venv = request.param
+    return request.param
+
+
+@pytest.fixture(params=[True, False], ids=["sitepackages=True", "sitepackages=False"])
+def sitepackages(request, venv):
+    venv.envconfig.sitepackages = request.param
+    return request.param

--- a/test/unit/test_configure.py
+++ b/test/unit/test_configure.py
@@ -23,18 +23,26 @@ def reset_pipfile_attributes():
 
 
 @pytest.mark.parametrize(
-    "variable_value, exp_pipfile, exp_pipfile_lock, exp_pipfile_parent",
+    "variable_value, exp_pipfile, exp_pipfile_fallback, exp_pipfile_lock, exp_pipfile_parent",
     (
-        ("", DEFAULT_PIPFILE + "_{envname}", DEFAULT_PIPFILE + ".lock", None),
+        (
+            "",
+            DEFAULT_PIPFILE + "_{envname}",
+            DEFAULT_PIPFILE,
+            DEFAULT_PIPFILE + ".lock",
+            None,
+        ),
         (
             DEFAULT_PIPFILE,
+            DEFAULT_PIPFILE + "_{envname}",
             DEFAULT_PIPFILE,
             None,
             py.path.local("."),
         ),
-        ("Poopfile", "Poopfile", None, py.path.local(".")),
+        ("Poopfile", "Poopfile_{envname}", "Poopfile", None, py.path.local(".")),
         (
             "/tmp/foo/bar/Pabstfile",
+            "Pabstfile_{envname}",
             "Pabstfile",
             None,
             py.path.local("/tmp/foo/bar"),
@@ -45,12 +53,14 @@ def test_pipenv_pipfile_is_set_after_configure(
     monkeypatch,
     variable_value,
     exp_pipfile,
+    exp_pipfile_fallback,
     exp_pipfile_lock,
     exp_pipfile_parent,
 ):
     monkeypatch.setenv("PIPENV_PIPFILE", variable_value)
     tox_pipenv.plugin.tox_configure(None)
     assert tox_pipenv.plugin.PIPFILE == exp_pipfile
-    assert tox_pipenv.plugin.PIPFILE_LOCK == exp_pipfile_lock or exp_pipfile + ".lock"
+    assert tox_pipenv.plugin.PIPFILE_FALLBACK == exp_pipfile_fallback
+    assert tox_pipenv.plugin.PIPFILE_LOCK == exp_pipfile_fallback + ".lock"
     assert tox_pipenv.plugin.PIPFILE_LOCK_ENV == exp_pipfile + ".lock"
     assert tox_pipenv.plugin.PIPFILE_PARENT == exp_pipfile_parent

--- a/test/unit/test_plugin.py
+++ b/test/unit/test_plugin.py
@@ -1,0 +1,27 @@
+"""
+Miscellaneous plugin-specific unit tests.
+
+Many of these tests are "brittle" and may need to be removed or rewritten when
+plugin internals change.
+"""
+import pytest
+
+import tox_pipenv.plugin
+
+
+@pytest.mark.parametrize(
+    "pipfile_parent",
+    (True, None),
+)
+def test_try_pipfile_lock_names(monkeypatch, venv, pipfile_parent):
+    """Test pipfile lock fallback when PIPFILE_PARENT is set (from PIPFILE_PIPENV)."""
+    monkeypatch.setattr(tox_pipenv.plugin, "PIPFILE_PARENT", pipfile_parent)
+    try_pipfile_lock_names = tox_pipenv.plugin._try_pipfile_lock_names(venv)
+    assert next(try_pipfile_lock_names) == tox_pipenv.plugin.PIPFILE_LOCK_ENV.format(
+        envname=venv.envconfig.envname
+    )
+    if pipfile_parent:
+        assert next(try_pipfile_lock_names) == tox_pipenv.plugin.PIPFILE_LOCK
+    else:
+        with pytest.raises(StopIteration):
+            next(try_pipfile_lock_names)

--- a/test/unit/test_testenv_create.py
+++ b/test/unit/test_testenv_create.py
@@ -1,0 +1,48 @@
+import subprocess
+import sys
+
+import pytest
+
+from tox_pipenv.plugin import tox_testenv_create, _pipenv_env
+
+
+@pytest.mark.usefixtures("mock_for_Popen")
+def test_create(
+    venv,
+    action,
+    has_pipfile,
+    has_pipfile_lock,
+    has_skip_pipenv,
+    pipenv_venv,
+    sitepackages,
+):
+    """
+    Test that the plugin is active when deps are empty and a Pipfile is present.
+    """
+    exp_plugin_ran = (
+        pipenv_venv and not has_skip_pipenv and (has_pipfile or has_pipfile_lock)
+    )
+
+    result = tox_testenv_create(venv, action)
+
+    exp_args = []
+    if exp_plugin_ran:
+        assert result is True
+        if sitepackages:
+            exp_args.append("--site-packages")
+        exp_args.extend(("--python", "test-python"))
+    else:
+        assert result is None
+        return
+    assert subprocess.Popen.call_count == 1
+    subprocess.Popen.assert_called_with(
+        [
+            sys.executable,
+            "-m",
+            "pipenv",
+        ]
+        + exp_args,
+        action=action,
+        cwd=venv.path.dirpath(),
+        env=_pipenv_env(venv),
+    )

--- a/test/unit/test_testenv_install_deps.py
+++ b/test/unit/test_testenv_install_deps.py
@@ -150,7 +150,11 @@ def test_install_override(
     assert result is True
     assert subprocess.Popen.call_count == 1
     subprocess.Popen.assert_called_once_with(
-        shlex.split(install_command.format(opts="", packages=" ".join(deps))),
+        shlex.split(
+            install_command.replace("python", sys.executable).format(
+                opts="", packages=" ".join(deps)
+            )
+        ),
         action=action,
         cwd=venv.path.dirpath(),
         env=_pipenv_env(venv),

--- a/tox_pipenv/plugin.py
+++ b/tox_pipenv/plugin.py
@@ -198,6 +198,9 @@ def _expand_install_command(command, packages, options):
         else:
             yield val
 
+    if command[0] == "python":
+        # expand "python" to the tox python, not the env python
+        command = list(itertools.chain([sys.executable], command[1:]))
     return list(itertools.chain.from_iterable(_expand_item(val) for val in command))
 
 

--- a/tox_pipenv/plugin.py
+++ b/tox_pipenv/plugin.py
@@ -53,12 +53,9 @@ _init_global_pipfile_from_env_var()
 
 def _try_pipfile_names(venv):
     """Iterate possible Pipfile names for the current venv."""
-    seen_names = set()
     for name in (PIPFILE, PIPFILE_FALLBACK):
         fmt_name = name.format(envname=venv.envconfig.envname)
-        if fmt_name not in seen_names:
-            seen_names.add(fmt_name)
-            yield fmt_name
+        yield fmt_name
 
 
 def _try_pipfile_lock_names(venv):

--- a/tox_pipenv/plugin.py
+++ b/tox_pipenv/plugin.py
@@ -289,11 +289,11 @@ def tox_testenv_create(venv, action):
 
     args.extend(["--python", str(config_interpreter)])
 
-    if hasattr(venv.envconfig, "make_emptydir"):
-        venv.envconfig.make_emptydir(venv.path)
-    else:
+    try:
         # tox 3.8.0 removed make_emptydir, See tox #1219
         tox.venv.cleanup_for_venv(venv)
+    except AttributeError:  # pragma: no cover
+        venv.envconfig.make_emptydir(venv.path)
 
     # Pipfile must exist in the venv directory
     _ensure_pipfile(venv)


### PR DESCRIPTION
# `tox_testenv_create`

PR #1 killed pipenv virtualenv creation in favor of just re-using whatever tox made for the environment... but this would be seen as a major regression in functionality that couldn't be easily replace (whereas overriding the `install_deps` process is relatively common and straightforward).

So bring back the virtualenv creation functionality (with a toggle to fall back to the tox environment).

# ...and allow custom env-specific `Pipfile`.

For example, I can now have different pipfiles for python2 and python3 (and lint, docs, publish, etc) and keep those and the lock files out of the repo root.

```
mkdir .tox-pipenv
cd .tox-pipenv
ln -s ../Pipfile Pipfile
# create a Pipfile_py27 if desired
PIPENV_PIPFILE=.tox-pipenv/Pipfile tox --pipenv-lock --recreate
# lock files for each environment are created in `.tox-pipenv`
```

